### PR TITLE
Do not close plot automatically 

### DIFF
--- a/egopowerflow/tools/plot.py
+++ b/egopowerflow/tools/plot.py
@@ -68,14 +68,13 @@ def plot_line_loading(network, timestep=0, filename=None):
         plt.show()
     else:
         plt.savefig(filename)
+        plt.close()
 
-    plt.close()
-        
 def plot_stacked_gen(network, bus=None, resolution='GW'):
     """
     Plot stacked sum of generation grouped by carrier type
-    
-    
+
+
     Parameters
     ----------
     network : PyPSA network container


### PR DESCRIPTION
When I use Spyder with console, plots for line-loading are closed automatically, which is kind of annoying. Is my fix ok for you @gplssm . I know, you have not much time, but just to inform you..